### PR TITLE
nodeのバージョン削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "eslint-config-prettier": "9.0.0",
     "prettier": "^3.0.3",
     "prettier-plugin-tailwindcss": "0.5.4"
-  },
-  "engines": {
-    "node": ">=18.17.0"
   }
 }


### PR DESCRIPTION
Vercelのデプロイで以下のエラーが表示され、こけてるのでnodeの指定を削除

```
Warning: Detected "engines": { "node": ">=18.17.0" } in your `package.json` that will automatically upgrade when a new major Node.js Version is released. Learn More: http://vercel.link/node-version
```