### PR TITLE
検索とページネーションの追加

### DIFF
--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -5,8 +5,9 @@ import { CreateInvoice } from '@/app/ui/invoices/buttons';
 import { lusitana } from '@/app/ui/fonts';
 import { InvoicesTableSkeleton } from '@/app/ui/skeletons';
 import { Suspense } from 'react';
+import { fetchInvoicesPages } from '@/app/lib/data';
 
-export default function Page({
+export default async function Page({
   searchParams,
 }: {
   searchParams?: {
@@ -16,6 +17,8 @@ export default function Page({
 }) {
   const query = searchParams?.query || '';
   const currentPage = Number(searchParams?.page) || 1;
+
+  const totalPages = await fetchInvoicesPages(query);
 
   return (
     <div className="w-full">
@@ -30,7 +33,7 @@ export default function Page({
         <Table query={query} currentPage={currentPage} />
       </Suspense>
       <div className="mt-5 flex w-full justify-center">
-        {/* <Pagination totalPages={totalPages} /> */}
+        <Pagination totalPages={totalPages} />
       </div>
     </div>
   )

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,3 +1,37 @@
-export default function Page() {
-  return <p>Invoices Page</p>;
+import Pagination from '@/app/ui/invoices/pagination';
+import Search from '@/app/ui/search';
+import Table from '@/app/ui/invoices/table';
+import { CreateInvoice } from '@/app/ui/invoices/buttons';
+import { lusitana } from '@/app/ui/fonts';
+import { InvoicesTableSkeleton } from '@/app/ui/skeletons';
+import { Suspense } from 'react';
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams?: {
+    query?: string;
+    page?: string;
+  };
+}) {
+  const query = searchParams?.query || '';
+  const currentPage = Number(searchParams?.page) || 1;
+
+  return (
+    <div className="w-full">
+      <div className="flex w-full items-center justify-between">
+        <h1 className={`${lusitana.className} text-2xl`}>Invoices</h1>
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-2 md:mt-8">
+        <Search placeholder="Search invoices..." />
+        <CreateInvoice />
+      </div>
+       <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
+        <Table query={query} currentPage={currentPage} />
+      </Suspense>
+      <div className="mt-5 flex w-full justify-center">
+        {/* <Pagination totalPages={totalPages} /> */}
+      </div>
+    </div>
+  )
 }

--- a/app/ui/invoices/pagination.tsx
+++ b/app/ui/invoices/pagination.tsx
@@ -4,17 +4,24 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { generatePagination } from '@/app/lib/utils';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 export default function Pagination({ totalPages }: { totalPages: number }) {
-  // NOTE: comment in this code when you get to this point in the course
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentPage = Number(searchParams.get('page')) || 1;
 
-  // const allPages = generatePagination(currentPage, totalPages);
+  const createPageURL = (pageNumber: number | string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('page', pageNumber.toString());
+    return `${pathname}?${params.toString()}`
+  }
+
+  const allPages = generatePagination(currentPage, totalPages);
 
   return (
     <>
-      {/* NOTE: comment in this code when you get to this point in the course */}
-
-      {/* <div className="inline-flex">
+      <div className="inline-flex">
         <PaginationArrow
           direction="left"
           href={createPageURL(currentPage - 1)}
@@ -47,7 +54,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
           href={createPageURL(currentPage + 1)}
           isDisabled={currentPage >= totalPages}
         />
-      </div> */}
+      </div>
     </>
   );
 }

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -10,8 +10,8 @@ export default function Search({ placeholder }: { placeholder: string }) {
   const { replace } = useRouter();
 
   const handleSearch = useDebouncedCallback((term) => {
-    console.log(`Searching... ${term}`);
     const params = new URLSearchParams(searchParams);
+    params.set('page', '1');
     if (term) {
       params.set('query', term);
     } else {

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -1,8 +1,25 @@
 'use client';
 
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useDebouncedCallback } from 'use-debounce';
 
 export default function Search({ placeholder }: { placeholder: string }) {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { replace } = useRouter();
+
+  const handleSearch = useDebouncedCallback((term) => {
+    console.log(`Searching... ${term}`);
+    const params = new URLSearchParams(searchParams);
+    if (term) {
+      params.set('query', term);
+    } else {
+      params.delete('query');
+    }
+    replace(`${pathname}?${params.toString()}`)
+  }, 300)
+
   return (
     <div className="relative flex flex-1 flex-shrink-0">
       <label htmlFor="search" className="sr-only">
@@ -11,6 +28,10 @@ export default function Search({ placeholder }: { placeholder: string }) {
       <input
         className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
         placeholder={placeholder}
+        onChange={(e) => {
+          handleSearch(e.target.value)
+        }}
+        defaultValue={searchParams.get('query')?.toString()}
       />
       <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.2.2",
+        "use-debounce": "^10.0.0",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -7098,6 +7099,17 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.0.tgz",
+      "integrity": "sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/utf-8-validate": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.2.2",
+    "use-debounce": "^10.0.0",
     "zod": "^3.22.2"
   },
   "devDependencies": {


### PR DESCRIPTION
第11章 検索とページネーションの追加の実装
https://nextjs.org/learn/dashboard-app/adding-search-and-pagination

**プレビュー**
https://nextjs-dashboard-git-feature-adding-search-a-eca76b-nittashiori.vercel.app/dashboard/invoices

---

## URLの検索パラメータを使用する理由は？
- ブックマーク可能で共有可能なURL：検索されてる状態を共有できる
- サーバーサイドレンダリングと初期読み込み：初期状態をレンダリングするため、サーバサイドレンダリングの処理が用意
- アナリティクスとトラッキング：ユーザーの行動を追跡するのが容易

## 検索機能の追加
- `useSearchParams`：現在のURLのパラメータにアクセスすることができる
  - 例：URLが/dashboard/invoices?page=1&query=pendingの場合、search paramsは`{page: '1', query: 'pending'}`になる
- `usePathname `：現在のURLのパス名を読み取る
  - 例：ルートが/dashboard/invoicesの場合、usePathnameは`'/dashboard/invoices' `になる
- `useRouter `：クライアントのコンポーネント内でルート間をプログラムで移動できる

### 実装の手順
1. ユーザーの入力をキャプチャします。
2. 検索パラメータでURLを更新します。
3. URLを入力フィールドと同期させます。
4. テーブルを検索クエリに応じて更新します。

### ベストプラクティス：デバウンシング
- デバウンシングは、関数が発火できる頻度を制限するプログラミングの手法である。
- ユーザーが入力を停止したときにのみデータベースにクエリを送る
- デバウンシングを使う理由は、検索ボックスを入力すると1文字1文字取得し新しいリクエストをデータベースに送信してしまうためで、小規模なら問題ないが何千ものユーザーがいる場合は良くない。 

#### デバウンシングの仕組み
1. イベントのトリガー：デバウンシングされるべきイベント（例えば、検索ボックスでのキーストローク）が発生すると、タイマーを開始。
2. 待機：タイマーの期限が切れる前に新しいイベントが発生した場合、タイマーはリセット。
3. 実行：タイマーがカウントダウンを終えると、デバウンシングされた関数が実行。

#### use-debounceの使用
```
npm i use-debounce
```

## ページネーション追加
テーブルの件数が6件まで表示しないようになってるため、ページネーションを追加する。

### ステップ
`/app/ui/invoices/pagination.tsx`で以下の処理を行う。
- createPageURLは現在の検索パラメータのインスタンスを作成する。
- "page"パラメータを指定されたページ番号に更新する。
- 最後に、pathnameと更新された検索パラメータを使用して完全なURLを構築する。